### PR TITLE
Add missing functionality to Add button

### DIFF
--- a/src/app/views/partials/checkboxes.html
+++ b/src/app/views/partials/checkboxes.html
@@ -15,7 +15,7 @@
                 <label>Write some todo task here...</label>
                 <input ng-model="vm.todoText" name="taskText" required>
             </md-input-container>
-            <md-button class="md-fab md-wayrn md-mini">
+            <md-button class="md-fab md-wayrn md-mini" ng-click="vm.addTodo($event)">
                 <i class="material-icons">add</i>
             </md-button>
         </div>


### PR DESCRIPTION
Current functionality, user had to hit enter to call the form submit and the plus button did nothing. Adds ng-click to element to allow for user to add items with the add button as well.